### PR TITLE
Separate branch to build robotiq_description with openrave_catkin by default

### DIFF
--- a/robotiq_description/CMakeLists.txt
+++ b/robotiq_description/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(robotiq_description)
 
 find_package(catkin REQUIRED COMPONENTS
-#  openrave_catkin
+  openrave_catkin
 )
 
 catkin_package()

--- a/robotiq_description/package.xml
+++ b/robotiq_description/package.xml
@@ -13,7 +13,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
   <depend>rospy</depend>
-  <!-- <depend>openrave_catkin</depend> -->
+  <depend>openrave_catkin</depend>
 
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>urdf</exec_depend>


### PR DESCRIPTION
In robotiq_description/CMakeLists.txt, openrave_catkin dependency was commented out in commit c1035e434654107ff2d739e06c41ef2e4cf1d844 and yet the installation commands that depends on openrave_catkin-introduced-environment-variables remains, such as in this line:

```
install(DIRECTORY meshes
                  DESTINATION ${OpenRAVE_DEVEL_DIR}/${OpenRAVE_DATA_DIR}/robots)
```

In this PR I propose having a separate branch that enables dependency on openrave_catkin by default in order to ensure certain packages to work. One relevant example is [this](https://github.com/crigroup/osr_course_pkgs/issues/5).